### PR TITLE
Fix: Properly escape additional script args (#3627)

### DIFF
--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -47,7 +47,7 @@ test('runs script containing spaces', (): Promise<void> => {
   return runRun(['build'], {}, 'spaces', async (config): ?Promise<void> => {
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
     // The command get's called with a space appended
-    const args = ['build', config, pkg.scripts.build + ' ', config.cwd];
+    const args = ['build', config, pkg.scripts.build, config.cwd];
 
     expect(execCommand).toBeCalledWith(...args);
   });
@@ -58,7 +58,7 @@ test('properly handles extra arguments and pre/post scripts', (): Promise<void> 
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
     const poststart = ['poststart', config, pkg.scripts.poststart, config.cwd];
     const prestart = ['prestart', config, pkg.scripts.prestart, config.cwd];
-    const start = ['start', config, pkg.scripts.start + ' --hello', config.cwd];
+    const start = ['start', config, pkg.scripts.start + ' "--hello"', config.cwd];
 
     expect(execCommand.mock.calls[0]).toEqual(prestart);
     expect(execCommand.mock.calls[1]).toEqual(start);
@@ -69,7 +69,7 @@ test('properly handles extra arguments and pre/post scripts', (): Promise<void> 
 test('properly handle bin scripts', (): Promise<void> => {
   return runRun(['cat-names'], {}, 'bin', config => {
     const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
-    const args = ['cat-names', config, `"${script}" `, config.cwd];
+    const args = ['cat-names', config, `"${script}"`, config.cwd];
 
     expect(execCommand).toBeCalledWith(...args);
   });
@@ -88,7 +88,16 @@ test('properly handle env command', (): Promise<void> => {
 test('retains string delimiters if args have spaces', (): Promise<void> => {
   return runRun(['cat-names', '--filter', 'cat names'], {}, 'bin', config => {
     const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
-    const args = ['cat-names', config, `"${script}" --filter "cat names"`, config.cwd];
+    const args = ['cat-names', config, `"${script}" "--filter" "cat names"`, config.cwd];
+
+    expect(execCommand).toBeCalledWith(...args);
+  });
+});
+
+test('retains quotes if args have spaces and quotes', (): Promise<void> => {
+  return runRun(['cat-names', '--filter', '"cat names"'], {}, 'bin', config => {
+    const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
+    const args = ['cat-names', config, `"${script}" "--filter" "\\"cat names\\""`, config.cwd];
 
     expect(execCommand).toBeCalledWith(...args);
   });

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -11,15 +11,9 @@ import map from '../../util/map.js';
 const leven = require('leven');
 const path = require('path');
 
-function sanitizedArgs(args: Array<string>): Array<string> {
-  const newArgs = [];
-  for (let arg of args) {
-    if (/\s/.test(arg)) {
-      arg = `"${arg}"`;
-    }
-    newArgs.push(arg);
-  }
-  return newArgs;
+// Copied from https://github.com/npm/npm/blob/63f153c743f9354376bfb9dad42bd028a320fd1f/lib/run-script.js#L175
+function joinArgs(args: Array<string>): string {
+  return args.reduce((joinedArgs, arg) => joinedArgs + ' "' + arg.replace(/"/g, '\\"') + '"', '');
 }
 
 export function setFlags() {}
@@ -79,7 +73,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       process.env.YARN_SILENT = '1';
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
-        const defaultScriptCmd = `${cmd} ${sanitizedArgs(args).join(' ')}`;
+        const defaultScriptCmd = cmd + joinArgs(args);
         const cmdWithArgs = stage === action ? defaultScriptCmd : cmd;
         await execCommand(stage, config, cmdWithArgs, config.cwd);
       }


### PR DESCRIPTION
**Summary**

Fixes #3595.

We were naively adding quotes around arguments that contain spaces but not doing any additional bash/shell escaping. Additionally, we were not compensating for `node` not giving access to raw arguments and were passing parsed arguments to any scripts without reescaping them. This patch tries to fix the madness by replicating `npm`s escaping.

**Test plan**

Existing `run` tests and one additional test.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
