### PR TITLE
Update: use a named version folder in NPM tarballs (#4094)

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -13,7 +13,7 @@ ensureAvailable lintian
 ensureAvailable rpmbuild
 
 PACKAGE_TMPDIR=tmp/debian_pkg
-VERSION=`dist/bin/yarn --version`
+VERSION=`./artifacts/yarn-legacy-* --version`
 OUTPUT_DIR=artifacts
 TARBALL_NAME=$OUTPUT_DIR/yarn-v$VERSION.tar.gz
 DEB_PACKAGE_NAME=yarn_$VERSION'_all.deb'

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -8,11 +8,9 @@ umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
 # Workaround for https://github.com/yarnpkg/yarn/issues/2591
 case "$(uname -s)" in
   *CYGWIN*|MSYS*|MINGW*)
-    dist_yarn=dist/bin/yarn.cmd
     system_yarn=yarn.cmd
     ;;
   *)
-    dist_yarn=dist/bin/yarn
     system_yarn=yarn
     ;;
 esac
@@ -49,5 +47,17 @@ cp node_modules/v8-compile-cache/v8-compile-cache.js dist/lib/v8-compile-cache.j
 # Verify that it works as expected
 [[ "$version" == "$(./dist/bin/yarn --version)" ]] || exit 1;
 
-./scripts/update-dist-manifest.js $(readlink -f dist/package.json) tar
-tar -cvzf artifacts/yarn-v$version.tar.gz dist/*
+./scripts/update-dist-manifest.js $(node -p -e "require('fs').realpathSync('dist/package.json')") tar
+
+case "$(tar --version)" in
+  *GNU*)
+    tar -cvzf artifacts/yarn-v$version.tar.gz --transform="s/^dist/yarn-v$version/" dist/*
+    ;;
+  bsdtar*)
+    tar -cvzf artifacts/yarn-v$version.tar.gz -s "/^dist/yarn-v$version/" dist/*
+    ;;
+  *)
+    echo "Can't determine tar type (BSD/GNU)!"
+    exit 1
+    ;;
+esac

--- a/scripts/update-dist-manifest.js
+++ b/scripts/update-dist-manifest.js
@@ -9,11 +9,15 @@
  */
 
 const fs = require('fs');
-
 const packageManifestFilename = process.argv[2];
 const packageManifest = require(packageManifestFilename);
 
 packageManifest.installationMethod = process.argv[3];
+
+if (!packageManifest.installationMethod) {
+  throw new Error('You need to specify an installation method.');
+}
+
 delete packageManifest.dependencies;
 delete packageManifest.devDependencies;
 delete packageManifest.scripts;


### PR DESCRIPTION
**Summary**

Fixes #3758. Makes the top-level folder in the tar archives have a name like `yarn-vX.Y.Z` instead of `dist` using the `--transform` and `-s` options in `tar` (they are different in GNU and BSD `tar`).

**Test plan**

Run `yarn build-dist` and then `tar -ztvf artifacts/yarn-v1.0.0.tar.gz`. Make sure the output lists all the files under `yarn-v1.0.0` directory.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
