### PR TITLE
Fix: stop all active spinners on reporter.close() (#4150)

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -145,3 +145,10 @@ exports[`Spinner 2`] = `"[1G⠁ [0K[1G⠂ foo[0K"`;
 exports[`Spinner 3`] = `"[1G⠁ [0K[1G⠂ foo[0K[1G⠄ bar[0K"`;
 
 exports[`Spinner 4`] = `"[1G⠁ [0K[1G⠂ foo[0K[1G⠄ bar[0K[2K[1G"`;
+
+exports[`close 1`] = `
+Object {
+  "stderr": "[2K[1G[1G░░ 0/2[1G█░ 1/2[1G⠁ [0K[2K[1G[2K[1G",
+  "stdout": "",
+}
+`;

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -244,3 +244,23 @@ test('Spinner', () => {
   spinner.stop();
   expect(data).toMatchSnapshot();
 });
+
+test('close', async () => {
+  jest.useFakeTimers();
+  expect(
+    await getConsoleBuff(r => {
+      r.noProgress = false; // we need this to override is-ci when running tests on ci
+      const tick = r.progress(2);
+      tick();
+      jest.runAllTimers();
+      tick();
+
+      const activity = r.activity();
+      activity.tick('foo');
+
+      r.close();
+      // .close() should stop all timers and activities
+      jest.runAllTimers();
+    }),
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
**Summary**

We were not stopping any activities in the reporter and were
relying on `process.exit()` to kill them earlier. This patch
fixes that and ensures all activities are stopped when the
reporter is closed.

**Test plan**

Adds a new snapshots test that fails without the fix.

Manual: just try to install a non-existent package and see `yarn`
getting stuck due to an ongoing reporter activity. After the fix,
it shuts down properly.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
