### PR TITLE
Update: Separate lockfile into its own npm package (#4114)

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import Lockfile from '../../src/lockfile/wrapper.js';
+import Lockfile from '../../src/lockfile';
 import {ConsoleReporter} from '../../src/reporters/index.js';
 import {Reporter} from '../../src/reporters/index.js';
-import {parse} from '../../src/lockfile/wrapper.js';
+import {parse} from '../../src/lockfile';
 import * as constants from '../../src/constants.js';
 import {run as check} from '../../src/cli/commands/check.js';
 import * as fs from '../../src/util/fs.js';

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -12,9 +12,9 @@ import {
 } from './_helpers.js';
 import {Add, run as add} from '../../src/cli/commands/add.js';
 import * as constants from '../../src/constants.js';
-import {parse} from '../../src/lockfile/wrapper.js';
+import {parse} from '../../src/lockfile';
 import {Install} from '../../src/cli/commands/install.js';
-import Lockfile from '../../src/lockfile/wrapper.js';
+import Lockfile from '../../src/lockfile';
 import {run as check} from '../../src/cli/commands/check.js';
 import * as fs from '../../src/util/fs.js';
 import semver from 'semver';

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -3,7 +3,7 @@
 import {run as buildRun, runInstall} from './_helpers.js';
 import * as checkCmd from '../../src/cli/commands/check.js';
 import {Install} from '../../src/cli/commands/install.js';
-import Lockfile from '../../src/lockfile/wrapper.js';
+import Lockfile from '../../src/lockfile';
 import * as reporters from '../../src/reporters/index.js';
 import type {CLIFunctionReturn} from '../../src/types.js';
 import * as fs from '../../src/util/fs.js';

--- a/__tests__/commands/import.js
+++ b/__tests__/commands/import.js
@@ -3,7 +3,7 @@
 import type {CLIFunctionReturn} from '../../src/types.js';
 import * as reporters from '../../src/reporters/index.js';
 import * as importCmd from '../../src/cli/commands/import.js';
-import Lockfile from '../../src/lockfile/wrapper.js';
+import Lockfile from '../../src/lockfile';
 import * as fs from '../../src/util/fs.js';
 import {run as buildRun} from './_helpers.js';
 

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -7,9 +7,9 @@ import {run as cache} from '../../../src/cli/commands/cache.js';
 import {run as check} from '../../../src/cli/commands/check.js';
 import * as constants from '../../../src/constants.js';
 import * as reporters from '../../../src/reporters/index.js';
-import {parse} from '../../../src/lockfile/wrapper.js';
+import {parse} from '../../../src/lockfile';
 import {Install, run as install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile/wrapper.js';
+import Lockfile from '../../../src/lockfile';
 import * as fs from '../../../src/util/fs.js';
 import {getPackageVersion, explodeLockfile, runInstall, createLockfile, run as buildRun} from '../_helpers.js';
 

--- a/__tests__/commands/install/lockfiles.js
+++ b/__tests__/commands/install/lockfiles.js
@@ -4,7 +4,7 @@ import {run as check} from '../../../src/cli/commands/check.js';
 import * as constants from '../../../src/constants.js';
 import * as reporters from '../../../src/reporters/index.js';
 import {Install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile/wrapper.js';
+import Lockfile from '../../../src/lockfile';
 import * as fs from '../../../src/util/fs.js';
 import {getPackageVersion, isPackagePresent, runInstall} from '../_helpers.js';
 import {promisify} from '../../../src/util/promise';

--- a/__tests__/commands/install/unit.js
+++ b/__tests__/commands/install/unit.js
@@ -2,7 +2,7 @@
 
 import {NoopReporter} from '../../../src/reporters/index.js';
 import {Install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile/wrapper.js';
+import Lockfile from '../../../src/lockfile';
 import Config from '../../../src/config.js';
 
 const path = require('path');

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint quotes: 0 */
 
-import Lockfile from '../src/lockfile/wrapper.js';
+import Lockfile from '../src/lockfile';
 import stringify from '../src/lockfile/stringify.js';
 import parse from '../src/lockfile/parse.js';
 import nullify from '../src/util/map.js';

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -2,7 +2,7 @@
 
 import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
 import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile/wrapper.js';
+import Lockfile from '../src/lockfile';
 import type PackageReference from '../src/package-reference.js';
 import type Config from '../src/config.js';
 import type {Manifest} from '../src/types.js';

--- a/__tests__/package-request.js
+++ b/__tests__/package-request.js
@@ -3,7 +3,7 @@
 import PackageRequest from '../src/package-request.js';
 import * as reporters from '../src/reporters/index.js';
 import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile/wrapper.js';
+import Lockfile from '../src/lockfile';
 import Config from '../src/config.js';
 
 async function prepareRequest(pattern, version, resolved): Object {

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -3,7 +3,7 @@
 
 import * as reporters from '../src/reporters/index.js';
 import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile/wrapper.js';
+import Lockfile from '../src/lockfile';
 import Config from '../src/config.js';
 import makeTemp from './_temp.js';
 import * as fs from '../src/util/fs.js';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ const ver = process.versions.node;
 const majorVer = parseInt(ver.split('.')[0], 10);
 
 const build = (lib, opts) =>
-  gulp.src('src/**/*')
+  gulp.src('src/**/*.js')
       .pipe(plumber({
         errorHandler(err) {
           gutil.log(err.stack);

--- a/packages/lockfile/README.md
+++ b/packages/lockfile/README.md
@@ -1,0 +1,18 @@
+# yarn-lockfile
+parse and/or write `yarn.lock` files
+
+## Usage Example
+
+```js
+const fs = require('fs')
+const lockfile = require('yarn-lockfile')
+
+let file = fs.readFileSync('yarn.lock', 'utf8')
+let json = lockfile.parse(file)
+
+console.log(json)
+
+let fileAgain = lockfile.stringify(json)
+
+console.log(fileAgain)
+```

--- a/packages/lockfile/package.json
+++ b/packages/lockfile/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "yarn-lockfile",
+  "version": "1.0.0",
+  "description": "The parser/stringifier for yarn lockfiles.",
+  "main": "index.js",
+  "license": "BSD-2-Clause"
+}

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -16,7 +16,10 @@ const babelRc = JSON.parse(fs.readFileSync(path.join(basedir, '.babelrc'), 'utf8
 
 const compiler = webpack({
   // devtool: 'inline-source-map',
-  entry: path.join(basedir, 'src/cli/index.js'),
+  entry: {
+    [`artifacts/yarn-${version}.js`]: path.join(basedir, 'src/cli/index.js'),
+    'packages/lockfile/index.js': path.join(basedir, 'src/lockfile/index.js'),
+  },
   module: {
     loaders: [
       {
@@ -33,8 +36,8 @@ const compiler = webpack({
     }),
   ],
   output: {
-    filename: `yarn-${version}.js`,
-    path: path.join(basedir, 'artifacts'),
+    filename: `[name]`,
+    path: basedir,
     libraryTarget: 'commonjs2',
   },
   target: 'node',

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -5,8 +5,8 @@ import type {InstallCwdRequest} from './install.js';
 import type {DependencyRequestPatterns, Manifest} from '../../types.js';
 import type Config from '../../config.js';
 import type {ListOptions} from './list.js';
-import Lockfile from '../../lockfile/wrapper.js';
-import PackageRequest from '../../package-request.js';
+import Lockfile from '../../lockfile';
+import {normalizePattern} from '../../util/normalize-pattern.js';
 import WorkspaceLayout from '../../workspace-layout.js';
 import {getExoticResolver} from '../../resolvers/index.js';
 import {buildTree} from './list.js';
@@ -60,7 +60,7 @@ export class Add extends Install {
    */
   getPatternVersion(pattern: string, pkg: Manifest): string {
     const {exact, tilde} = this.flags;
-    const {hasVersion, range} = PackageRequest.normalizePattern(pattern);
+    const {hasVersion, range} = normalizePattern(pattern);
     let version;
 
     if (getExoticResolver(pattern)) {

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -4,7 +4,7 @@ import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
 import {integrityErrors} from '../../integrity-checker.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import type {Reporter} from '../../reporters/index.js';
 import * as fs from '../../util/fs.js';
 import {Install} from './install.js';

--- a/src/cli/commands/generate-lock-entry.js
+++ b/src/cli/commands/generate-lock-entry.js
@@ -3,8 +3,7 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
-import {implodeEntry} from '../../lockfile/wrapper.js';
-import stringify from '../../lockfile/stringify.js';
+import {implodeEntry, stringify} from '../../lockfile';
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return false;

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -7,7 +7,7 @@ import {MessageError} from '../../errors.js';
 import {registries} from '../../registries/index.js';
 import NoopReporter from '../../reporters/base-reporter.js';
 import buildSubCommands from './_build-sub-commands.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import {Install} from './install.js';
 import {Add} from './add.js';
 import {run as runRemove} from './remove.js';

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -18,7 +18,8 @@ import PackageRequest from '../../package-request.js';
 import * as fetcher from '../../package-fetcher.js';
 import PackageLinker from '../../package-linker.js';
 import * as compatibility from '../../package-compatibility.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
+import {normalizePattern} from '../../util/normalize-pattern.js';
 import * as fs from '../../util/fs.js';
 import * as util from '../../util/misc.js';
 import {YARN_REGISTRY, LOCKFILE_FILENAME} from '../../constants.js';
@@ -42,7 +43,7 @@ class ImportResolver extends BaseResolver {
   }
 
   resolveHostedGit(info: Manifest, Resolver: Class<HostedGitResolver>): Manifest {
-    const {range} = PackageRequest.normalizePattern(this.pattern);
+    const {range} = normalizePattern(this.pattern);
     const exploded = explodeHostedGitFragment(range, this.reporter);
     const hash = (info: any).gitHead;
     invariant(hash, 'expected package gitHead');
@@ -59,7 +60,7 @@ class ImportResolver extends BaseResolver {
   }
 
   resolveGist(info: Manifest, Resolver: typeof GistResolver): Manifest {
-    const {range} = PackageRequest.normalizePattern(this.pattern);
+    const {range} = normalizePattern(this.pattern);
     const {id} = explodeGistFragment(range, this.reporter);
     const hash = (info: any).gitHead;
     invariant(hash, 'expected package gitHead');
@@ -92,7 +93,7 @@ class ImportResolver extends BaseResolver {
   }
 
   resolveFile(info: Manifest, Resolver: typeof FileResolver): Manifest {
-    const {range} = PackageRequest.normalizePattern(this.pattern);
+    const {range} = normalizePattern(this.pattern);
     let loc = util.removePrefix(range, 'file:');
     if (!path.isAbsolute(loc)) {
       loc = path.join(this.config.cwd, loc);
@@ -127,7 +128,7 @@ class ImportResolver extends BaseResolver {
   }
 
   resolveImport(info: Manifest): Manifest {
-    const {range} = PackageRequest.normalizePattern(this.pattern);
+    const {range} = normalizePattern(this.pattern);
     const Resolver = getExoticResolver(range);
     if (Resolver && Resolver.prototype instanceof HostedGitResolver) {
       return this.resolveHostedGit(info, Resolver);
@@ -150,7 +151,7 @@ class ImportResolver extends BaseResolver {
   }
 
   async resolve(): Promise<Manifest> {
-    const {name} = PackageRequest.normalizePattern(this.pattern);
+    const {name} = normalizePattern(this.pattern);
     let cwd = this.getCwd();
     while (!path.relative(this.config.cwd, cwd).startsWith('..')) {
       const loc = path.join(cwd, 'node_modules', name);

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -6,22 +6,22 @@ import type {ReporterSelectOption} from '../../reporters/types.js';
 import type {Manifest, DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {RegistryNames} from '../../registries/index.js';
-import type {LockfileObject} from '../../lockfile/wrapper.js';
+import type {LockfileObject} from '../../lockfile';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
 import {MessageError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
-import Lockfile from '../../lockfile/wrapper.js';
-import lockStringify from '../../lockfile/stringify.js';
+import Lockfile from '../../lockfile';
+import {stringify as lockStringify} from '../../lockfile';
 import * as fetcher from '../../package-fetcher.js';
 import PackageInstallScripts from '../../package-install-scripts.js';
 import * as compatibility from '../../package-compatibility.js';
 import PackageResolver from '../../package-resolver.js';
 import PackageLinker from '../../package-linker.js';
-import PackageRequest from '../../package-request.js';
 import {registries} from '../../registries/index.js';
 import {getExoticResolver} from '../../resolvers/index.js';
 import {clean} from './clean.js';
 import * as constants from '../../constants.js';
+import {normalizePattern} from '../../util/normalize-pattern.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 import {version as YARN_VERSION, getInstallationMethod} from '../../util/yarn-version.js';
@@ -218,7 +218,7 @@ export class Install {
       }
 
       // extract the name
-      const parts = PackageRequest.normalizePattern(pattern);
+      const parts = normalizePattern(pattern);
       excludeNames.push(parts.name);
     }
 

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import type {Manifest} from '../../types.js';
 import NoopReporter from '../../reporters/base-reporter.js';
 import {Install} from './install.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import buildSubCommands from './_build-sub-commands.js';
 
 const invariant = require('invariant');

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -6,7 +6,8 @@ import type PackageResolver from '../../package-resolver.js';
 import type PackageLinker from '../../package-linker.js';
 import type {Tree, Trees} from '../../reporters/types.js';
 import {Install} from './install.js';
-import Lockfile from '../../lockfile/wrapper.js';
+
+import Lockfile from '../../lockfile';
 import {isProduction} from '../../constants';
 
 const invariant = require('invariant');

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -3,7 +3,7 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import PackageRequest from '../../package-request.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import {Install} from './install.js';
 
 export const requireLockfile = true;

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -2,7 +2,7 @@
 
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import {registries} from '../../registries/index.js';
 import {Install} from './install.js';
 import {MessageError} from '../../errors.js';

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -2,11 +2,11 @@
 
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
-import PackageRequest from '../../package-request.js';
 import buildSubCommands from './_build-sub-commands.js';
 import {getToken} from './login.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import {MessageError} from '../../errors.js';
+import {normalizePattern} from '../../util/normalize-pattern.js';
 import {isValidPackageName} from '../../util/normalize-manifest/validate.js';
 
 export async function getName(args: Array<string>, config: Config): Promise<string> {
@@ -92,7 +92,7 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
         return false;
       }
 
-      const {name, range, hasVersion} = PackageRequest.normalizePattern(args.shift());
+      const {name, range, hasVersion} = normalizePattern(args.shift());
       if (!hasVersion) {
         throw new MessageError(reporter.lang('requiredVersionInRange'));
       }

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -4,7 +4,7 @@ import type {Dependency} from '../../types.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import inquirer from 'inquirer';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import {Add} from './add.js';
 import {getOutdated} from './upgrade.js';
 

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -4,8 +4,9 @@ import type {Dependency} from '../../types.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {Add} from './add.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import PackageRequest from '../../package-request.js';
+import {normalizePattern} from '../../util/normalize-pattern.js';
 import {Install} from './install.js';
 
 // used to detect whether a semver range is simple enough to preserve when doing a --latest upgrade.
@@ -19,7 +20,7 @@ const validScopeRegex = /^@[a-zA-Z0-9-][a-zA-Z0-9_.-]*\/$/g;
 // Also add ones that are missing, since the requested packages may not have been outdated at all.
 function setUserRequestedPackageVersions(deps: Array<Dependency>, args: Array<string>) {
   args.forEach(requestedPattern => {
-    const normalized = PackageRequest.normalizePattern(requestedPattern);
+    const normalized = normalizePattern(requestedPattern);
     const newPattern = `${normalized.name}@${normalized.range}`;
     let found = false;
 

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -7,7 +7,7 @@ import type {HoistManifestTuple, HoistManifestTuples} from '../../package-hoiste
 import {Install} from './install.js';
 import {METADATA_FILENAME, TARBALL_FILENAME} from '../../constants.js';
 import * as fs from '../../util/fs.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile';
 import {MessageError} from '../../errors.js';
 
 export const requireLockfile = true;

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -8,7 +8,7 @@ import * as fsUtil from '../util/fs.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 import {install} from '../cli/commands/install.js';
-import Lockfile from '../lockfile/wrapper.js';
+import Lockfile from '../lockfile';
 import Config from '../config.js';
 import {packTarball} from '../cli/commands/pack.js';
 

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type Config from './config.js';
-import type {LockManifest} from './lockfile/wrapper.js';
+import type {LockManifest} from './lockfile';
 import * as constants from './constants.js';
 import * as fs from './util/fs.js';
 import {sortAlpha, compareSortedArrays} from './util/misc.js';

--- a/src/lockfile/.gitignore
+++ b/src/lockfile/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -5,9 +5,9 @@ import type {Manifest, PackageRemote} from '../types.js';
 import type {RegistryNames} from '../registries/index.js';
 import type {ParseResultType} from './parse.js';
 import {sortAlpha} from '../util/misc.js';
-import PackageRequest from '../package-request.js';
+import {normalizePattern} from '../util/normalize-pattern.js';
 import parse from './parse.js';
-import * as constants from '../constants.js';
+import {LOCKFILE_FILENAME} from '../constants.js';
 import * as fs from '../util/fs.js';
 
 const invariant = require('invariant');
@@ -47,7 +47,7 @@ export type LockfileObject = {
 };
 
 function getName(pattern: string): string {
-  return PackageRequest.normalizePattern(pattern).name;
+  return normalizePattern(pattern).name;
 }
 
 function blankObjectUndefined(obj: ?Object): ?Object {
@@ -102,7 +102,7 @@ export default class Lockfile {
 
   static async fromDirectory(dir: string, reporter?: Reporter): Promise<Lockfile> {
     // read the manifest in this directory
-    const lockfileLoc = path.join(dir, constants.LOCKFILE_FILENAME);
+    const lockfileLoc = path.join(dir, LOCKFILE_FILENAME);
 
     let lockfile;
     let rawLockfile = '';

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -44,7 +44,7 @@ function isValidPropValueToken(token): boolean {
   return VALID_PROP_VALUE_TOKENS.indexOf(token.type) >= 0;
 }
 
-export function* tokenise(input: string): Iterator<Token> {
+function* tokenise(input: string): Iterator<Token> {
   let lastNewline = false;
   let line = 1;
   let col = 0;
@@ -162,7 +162,7 @@ export function* tokenise(input: string): Iterator<Token> {
   yield buildToken(TOKEN_TYPES.eof);
 }
 
-export class Parser {
+class Parser {
   constructor(input: string, fileLoc: string = 'lockfile') {
     this.comments = [];
     this.tokens = tokenise(input);

--- a/src/lockfile/stringify.js
+++ b/src/lockfile/stringify.js
@@ -3,7 +3,7 @@
 import {sortAlpha} from '../util/misc.js';
 import {LOCKFILE_VERSION} from '../constants.js';
 
-const YARN_VERSION = require('../../package.json').version;
+import {version as YARN_VERSION} from '../../package.json';
 const NODE_VERSION = process.version;
 
 function shouldWrapKey(str: string): boolean {

--- a/src/package-reference.js
+++ b/src/package-reference.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type Lockfile from './lockfile/wrapper.js';
+import type Lockfile from './lockfile';
 import type Config from './config.js';
 import type {PackageRemote, Manifest} from './types.js';
 import type PackageRequest from './package-request.js';

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -7,9 +7,10 @@ import type {Reporter} from './reporters/index.js';
 import {getExoticResolver} from './resolvers/index.js';
 import type Config from './config.js';
 import PackageRequest from './package-request.js';
+import {normalizePattern} from './util/normalize-pattern.js';
 import RequestManager from './util/request-manager.js';
 import BlockingQueue from './util/blocking-queue.js';
-import Lockfile from './lockfile/wrapper.js';
+import Lockfile from './lockfile';
 import map from './util/map.js';
 import WorkspaceLayout from './workspace-layout.js';
 import ResolutionMap from './resolution-map.js';
@@ -492,7 +493,7 @@ export default class PackageResolver {
     let fresh = false;
 
     if (lockfileEntry) {
-      const {range, hasVersion} = PackageRequest.normalizePattern(req.pattern);
+      const {range, hasVersion} = normalizePattern(req.pattern);
 
       if (this.isLockfileEntryOutdated(lockfileEntry.version, range, hasVersion)) {
         this.reporter.warn(this.reporter.lang('incorrectLockfileEntry', req.pattern));

--- a/src/rc.js
+++ b/src/rc.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import {dirname, resolve} from 'path';
-import parse from './lockfile/parse.js';
+import {parse} from './lockfile';
 import * as rcUtil from './util/rc.js';
 
 // Keys that will get resolved relative to the path of the rc file they belong to

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -5,8 +5,7 @@ import type RequestManager from '../util/request-manager.js';
 import type {ConfigRegistries} from './index.js';
 import {YARN_REGISTRY} from '../constants.js';
 import NpmRegistry from './npm-registry.js';
-import stringify from '../lockfile/stringify.js';
-import parse from '../lockfile/parse.js';
+import {stringify, parse} from '../lockfile';
 import * as fs from '../util/fs.js';
 import {version} from '../util/yarn-version.js';
 

--- a/src/resolution-map.js
+++ b/src/resolution-map.js
@@ -4,7 +4,7 @@ import minimatch from 'minimatch';
 import map from './util/map';
 import type Config from './config';
 import type {Reporter} from './reporters';
-import PackageRequest from './package-request';
+import {normalizePattern} from './util/normalize-pattern.js';
 import {getExoticResolver} from './resolvers';
 
 const DIRECTORY_SEPARATOR = '/';
@@ -75,7 +75,7 @@ export default class ResolutionMap {
   }
 
   find(reqPattern: string, parentNames: Array<string>): ?string {
-    const {name, range: reqRange} = PackageRequest.normalizePattern(reqPattern);
+    const {name, range: reqRange} = normalizePattern(reqPattern);
     const resolutions = this.resolutionsByPackage[name];
 
     if (!resolutions) {

--- a/src/util/normalize-pattern.js
+++ b/src/util/normalize-pattern.js
@@ -1,0 +1,43 @@
+/* @flow */
+/**
+ * Explode and normalize a pattern into its name and range.
+ */
+
+export function normalizePattern(
+  pattern: string,
+): {
+  hasVersion: boolean,
+  name: string,
+  range: string,
+} {
+  let hasVersion = false;
+  let range = 'latest';
+  let name = pattern;
+
+  // if we're a scope then remove the @ and add it back later
+  let isScoped = false;
+  if (name[0] === '@') {
+    isScoped = true;
+    name = name.slice(1);
+  }
+
+  // take first part as the name
+  const parts = name.split('@');
+  if (parts.length > 1) {
+    name = parts.shift();
+    range = parts.join('@');
+
+    if (range) {
+      hasVersion = true;
+    } else {
+      range = '*';
+    }
+  }
+
+  // add back @ scope suffix
+  if (isScoped) {
+    name = `@${name}`;
+  }
+
+  return {name, range, hasVersion};
+}

--- a/src/workspace-layout.js
+++ b/src/workspace-layout.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type Config from './config.js';
-import PackageRequest from './package-request.js';
+import {normalizePattern} from './util/normalize-pattern.js';
 import type {WorkspacesManifestMap, Manifest} from './types.js';
 
 const semver = require('semver');
@@ -21,7 +21,7 @@ export default class WorkspaceLayout {
   }
 
   getManifestByPattern(pattern: string): ?{loc: string, manifest: Manifest} {
-    const {name, range} = PackageRequest.normalizePattern(pattern);
+    const {name, range} = normalizePattern(pattern);
     const workspace = this.getWorkspaceManifest(name);
     if (!workspace || !semver.satisfies(workspace.manifest.version, range, this.config.looseSemver)) {
       return null;


### PR DESCRIPTION
**Summary**

Fixes #3879. Separates the lockfile parser as a separate npm package.

**Test plan**

Existing unit tests.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
