### PR TITLE
Fix: Use semver tag to colorize package name for outdated/upgrade-int…

### DIFF
--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -5,6 +5,8 @@ import type Config from '../../config.js';
 import PackageRequest from '../../package-request.js';
 import Lockfile from '../../lockfile';
 import {Install} from './install.js';
+import colorForVersions from '../../util/color-for-versions';
+import colorizeDiff from '../../util/colorize-diff.js';
 
 export const requireLockfile = true;
 
@@ -28,15 +30,14 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const getNameFromHint = hint => (hint ? `${hint}Dependencies` : 'dependencies');
-  const getColorFromVersion = ({current, wanted, name}) =>
-    current === wanted ? reporter.format.yellow(name) : reporter.format.red(name);
+  const colorizeName = ({current, wanted, name}) => reporter.format[colorForVersions(current, wanted)](name);
 
   if (deps.length) {
     const body = deps.map((info): Array<string> => {
       return [
-        getColorFromVersion(info),
+        colorizeName(info),
         info.current,
-        reporter.format.green(info.wanted),
+        colorizeDiff(info.current, info.wanted, reporter),
         reporter.format.magenta(info.latest),
         getNameFromHint(info.hint),
         reporter.format.cyan(info.url),

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,3 +105,17 @@ export function getPathKey(platform: string, env: Env): string {
 
   return pathKey;
 }
+
+export const VERSION_COLOR_SCHEME: {[key: string]: VersionColor} = {
+  major: 'red',
+  premajor: 'red',
+  minor: 'yellow',
+  preminor: 'yellow',
+  patch: 'green',
+  prepatch: 'green',
+  prerelease: 'red',
+  unchanged: 'white',
+  unknown: 'red',
+};
+
+export type VersionColor = 'red' | 'yellow' | 'green' | 'white';

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -111,7 +111,7 @@ const messages = {
   noFilePermission: "We don't have permissions to touch the file $0.",
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   legendColorsForUpgradeInteractive:
-    'Color legend : \n $0    : Patch Update backward-compatible bug fixes \n $1 : Minor Update backward-compatible features',
+    'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2  : Patch Update backward-compatible bug fixes',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
   fileWriteError: 'Could not write file $0: $1',
   multiplePackagesCantUnpackInSameDestination:

--- a/src/util/color-for-versions.js
+++ b/src/util/color-for-versions.js
@@ -1,0 +1,14 @@
+/* @flow */
+import semver from 'semver';
+import {VERSION_COLOR_SCHEME} from '../constants.js';
+import type {VersionColor} from '../constants.js';
+
+export default function(from: string, to: string): VersionColor {
+  const validFrom = semver.valid(from);
+  const validTo = semver.valid(to);
+  let versionBump = 'unknown';
+  if (validFrom && validTo) {
+    versionBump = semver.diff(validFrom, validTo) || 'unchanged';
+  }
+  return VERSION_COLOR_SCHEME[versionBump];
+}

--- a/src/util/colorize-diff.js
+++ b/src/util/colorize-diff.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+import type {Reporter} from '../reporters/index.js';
+
+export default function(from: string, to: string, reporter: Reporter): string {
+  const parts = to.split('.');
+  const fromParts = from.split('.');
+
+  const index = parts.findIndex((part, i) => part !== fromParts[i]);
+  const splitIndex = index >= 0 ? index : parts.length;
+
+  const colorized = reporter.format.green(parts.slice(splitIndex).join('.'));
+  return parts.slice(0, splitIndex).concat(colorized).join('.');
+}


### PR DESCRIPTION
…eractive commands (#4183)

**Summary**
This will fix #3815 by implementing a solution mentioned here https://github.com/yarnpkg/yarn/issues/3815#issuecomment-322496710.
As the `outdated`-command displayed pretty much the same data I changed the colors of that command as well.

New output: 
![screen shot 2017-08-16 at 10 22 05](https://user-images.githubusercontent.com/2036823/29357714-c91f457a-8278-11e7-99fc-ef1a3be65b3e.png)
![screen shot 2017-08-16 at 11 48 54](https://user-images.githubusercontent.com/2036823/29357746-e4c1c1ea-8278-11e7-8541-6f71213d686d.png)

**Test plan**

I did not create any new tests as this is only a visual change and was not tested before. But if we decide to move the new "helper files" to a utils folder I can write a few tests to test the output.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
