### PR TITLE
Chore: use npm@4 for publishing tarballs

### DIFF
--- a/scripts/update-npm.sh
+++ b/scripts/update-npm.sh
@@ -27,4 +27,4 @@ if [ "$release_type" = "rc" ]; then
   npm_flags='--tag rc'
 fi;
 
-eval "npm publish '$tarball' --access public $npm_flags"
+eval "npx npm@4 publish '$tarball' --access public $npm_flags"


### PR DESCRIPTION
**Summary**

Yarn 1.1.0 release failed due to a bug in npm@5:
https://github.com/npm/npm/issues/16723. This patch uses `npx` to
force using `np@4` when publishing in `update-npm.sh`.

**Test plan**

CircleCI

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
