### PR TITLE
Fix: Suppress "revealed multiple traversal of the same folder" warnin…

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -222,7 +222,7 @@ async function buildActionsForCopy(
     // TODO https://github.com/yarnpkg/yarn/issues/3751
     // related to bundled dependencies handling
     if (files.has(dest.toLowerCase())) {
-      reporter.warn(`The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy`);
+      reporter.verbose(`The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy`);
     } else {
       files.add(dest.toLowerCase());
     }


### PR DESCRIPTION
…gs (#4549)

**Summary**

Refs #3751. Changes `reporter.warn` to `reporter.verbose` for the message "The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy".

**Test plan**

Manual verification.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
