### PR TITLE
chore(utils): replace last `expandPath` with `resolveWithHome` (#4605)

### DIFF
--- a/__tests__/fixtures/global/add-with-prefix-env/.yarnrc
+++ b/__tests__/fixtures/global/add-with-prefix-env/.yarnrc
@@ -1,1 +1,1 @@
-prefix ""
+prefix false

--- a/__tests__/util/path.js
+++ b/__tests__/util/path.js
@@ -12,45 +12,7 @@ jest.mock('path', () => {
   return path;
 });
 
-import {expandPath, resolveWithHome} from '../../src/util/path.js';
-
-describe('expandPath', () => {
-  const realPlatform = process.platform;
-
-  describe('!win32', () => {
-    beforeAll(() => {
-      process.platform = 'notWin32';
-    });
-
-    afterAll(() => {
-      process.platform = realPlatform;
-    });
-
-    test('Paths get expanded', () => {
-      expect(expandPath('~/bar/baz/q')).toEqual('/home/foo/bar/baz/q');
-      expect(expandPath('  ~/bar/baz')).toEqual('/home/foo/bar/baz');
-      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
-      expect(expandPath('~/~/bar/baz')).toEqual('/home/foo/~/bar/baz');
-    });
-  });
-
-  describe('win32', () => {
-    beforeAll(() => {
-      process.platform = 'win32';
-    });
-
-    afterAll(() => {
-      process.platform = realPlatform;
-    });
-
-    test('Paths never get expanded', () => {
-      expect(expandPath('~/bar/baz/q')).toEqual('~/bar/baz/q');
-      expect(expandPath('  ~/bar/baz')).toEqual('  ~/bar/baz');
-      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
-      expect(expandPath('~/~/bar/baz')).toEqual('~/~/bar/baz');
-    });
-  });
-});
+import {resolveWithHome} from '../../src/util/path.js';
 
 describe('resolveWithHome', () => {
   const realPlatform = process.platform;

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ import type {Reporter} from './reporters/index.js';
 import type {Manifest, PackageRemote, WorkspacesManifestMap} from './types.js';
 import type PackageReference from './package-reference.js';
 import {execFromManifest} from './util/execute-lifecycle-script.js';
-import {expandPath} from './util/path.js';
+import {resolveWithHome} from './util/path.js';
 import normalizeManifest from './util/normalize-manifest/index.js';
 import {MessageError} from './errors.js';
 import * as fs from './util/fs.js';
@@ -192,10 +192,11 @@ export default class Config {
    * Get a config option from our yarn config.
    */
 
-  getOption(key: string, expand: boolean = false): mixed {
+  getOption(key: string, resolve: boolean = false): mixed {
     const value = this.registries.yarn.getOption(key);
-    if (expand && typeof value === 'string') {
-      return expandPath(value);
+
+    if (resolve && typeof value === 'string') {
+      return resolveWithHome(value);
     }
 
     return value;

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -53,10 +53,10 @@ function getGlobalPrefix(): string {
   }
 }
 
-const PATH_CONFIG_OPTIONS = ['cache', 'cafile', 'prefix', 'userconfig'];
+const PATH_CONFIG_OPTIONS = new Set(['cache', 'cafile', 'prefix', 'userconfig']);
 
 function isPathConfigOption(key: string): boolean {
-  return PATH_CONFIG_OPTIONS.indexOf(key) >= 0;
+  return PATH_CONFIG_OPTIONS.has(key);
 }
 
 function normalizePath(val: mixed): ?string {
@@ -65,7 +65,7 @@ function normalizePath(val: mixed): ?string {
   }
 
   if (typeof val !== 'string') {
-    val = '' + (val: any);
+    val = String(val);
   }
 
   return resolveWithHome(val);

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -8,17 +8,9 @@ export function getPosixPath(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
-export function expandPath(path: string): string {
-  if (process.platform !== 'win32') {
-    path = path.replace(/^\s*~(?=$|\/|\\)/, userHome);
-  }
-
-  return path;
-}
-
 export function resolveWithHome(path: string): string {
   const homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//;
-  if (path.match(homePattern)) {
+  if (homePattern.test(path)) {
     return resolve(userHome, path.substr(2));
   }
 


### PR DESCRIPTION
**Summary**

Looking at two solutions introduced in #3393 and #3756, the first one doesn't support win32, while the second does, sticking with the second one more beneficial and supports a wider range of OS.

Removed the stuff introduced in #3393 keeping only #3756.

#3756 also introduced config file normalization, so probably second argument to getOption is obsolete, will discover that and submit another PR if that's the case.

**Test plan**

Modified tests appropriately.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
