### PR TITLE
Update upstream

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -357,7 +357,9 @@ export default class Config {
 
     this.registries = map();
     this.cache = map();
-    this.cwd = opts.cwd || this.cwd || process.cwd();
+
+    // Ensure the cwd is always an absolute path.
+    this.cwd = path.resolve(opts.cwd || this.cwd || process.cwd());
 
     this.looseSemver = opts.looseSemver == undefined ? true : opts.looseSemver;
 


### PR DESCRIPTION
…991)

fixes #4984
fixes #5327

Summary

Previously the relative path to the script to run was being passed to the child_process function, plus the cwd was being set. This caused relative paths to be doubled.

For example if the current process.cwd() is /projects/sampleProject/subdir and you execute yarn --cwd .. run test then it would attempt to run the command

../node_modules/.bin/test

from

/projects/sampleProject

which is incorrect.

The fix here was to use path.resolve instead of .join to convert the script's location to an absolute path.

Test plan

Tested manually.

I tried to write a unit test for this, but under the current test framework an absolute dir was always passed to the script execution because config.cwd is always set to the absolute path for the test fixture.

Trying to set the config.cwd to a relative path causes tests to fail because they become relative to where yarn run test was executed (the root of the Yarn project).

I gave up 😢

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
