### PR TITLE
Update upstream

### DIFF
--- a/resources/debian/control.in
+++ b/resources/debian/control.in
@@ -1,7 +1,7 @@
 Package: yarn
 Version: $VERSION-1
 Recommends: nodejs
-Conflicts: nodejs (<< 4.0.0)
+Conflicts: nodejs (<< 4.0.0), cmdtest
 Section: devel
 Priority: optional
 Architecture: all


### PR DESCRIPTION
The `cmdtest` package also installs a `yarn` command, and people often get confused by this (see #2821). If we specify that the Yarn package conflicts with the cmdtest package, installing Yarn will automatically uninstall cmdtest.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
