### PR TITLE
Update upstream

### DIFF
--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -40,6 +40,18 @@ async function createTempPrefixFolder(): Promise<string> {
   return path.join(prefixFolder, 'bin');
 }
 
+async function linkAt(config, ...relativePath): Promise<string> {
+  const joinedPath = path.join(config.cwd, ...relativePath);
+  const stat = await fs.lstat(joinedPath);
+  if (stat.isSymbolicLink()) {
+    const linkPath = await fs.readlink(joinedPath);
+    return linkPath;
+  } else {
+    const contents = await fs.readFile(joinedPath);
+    return /node" +"\$basedir\/([^"]*\.js)"/.exec(contents)[1];
+  }
+}
+
 // these tests have global folder side or prefix folder effects, run it only in CI
 if (isCI) {
   test.concurrent('add without flag', (): Promise<void> => {
@@ -137,40 +149,34 @@ test.concurrent('upgrade', async (): Promise<void> => {
   const tmpPrefixFolder = await createTempPrefixFolder();
   const flags = {globalFolder: tmpGlobalFolder, prefix: tmpPrefixFolder};
   const upgradeFlags = {globalFolder: tmpGlobalFolder, prefix: tmpPrefixFolder, latest: true};
-  return runGlobal(['add', 'react-native-cli@2.0.0'], flags, 'add-with-prefix-flag', () => {}).then(() => {
-    return runGlobal(
-      ['upgrade', 'react-native-cli'],
-      upgradeFlags,
-      'add-with-prefix-flag',
-      (config, reporter, install, getStdout) => {
-        expect(getStdout()).toContain('react-native-cli');
-        expect(getStdout()).not.toContain('react-native-cli@2.0.0');
-      },
-    );
-  });
+  await runGlobal(['add', 'react-native-cli@2.0.0'], flags, 'add-with-prefix-flag', () => {});
+
+  return runGlobal(
+    ['upgrade', 'react-native-cli'],
+    upgradeFlags,
+    'add-with-prefix-flag',
+    (config, reporter, install, getStdout) => {
+      expect(getStdout()).toContain('react-native-cli');
+      expect(getStdout()).not.toContain('react-native-cli@2.0.0');
+    },
+  );
 });
 
 test.concurrent('symlink update', async (): Promise<void> => {
   const tmpGlobalFolder = await createTempGlobalFolder();
   const tmpPrefixFolder = await createTempPrefixFolder();
   const flags = {globalFolder: tmpGlobalFolder, prefix: tmpPrefixFolder};
-  return runGlobal(['add', 'dummy-for-testing-changed-path@v0.0.3'], flags, 'add-with-prefix-flag', async config => {
-    expect(await fs.exists(path.join(tmpGlobalFolder, 'node_modules', 'dummy-for-testing-changed-path'))).toEqual(true);
-    const dummyPath = path.join(tmpPrefixFolder, 'bin', 'dummy-for-testing-changed-path');
-
-    expect(await fs.exists(dummyPath)).toEqual(true);
-    const targetBefore = await fs.readlink(dummyPath);
-
-    await runGlobal(
-      ['upgrade', 'dummy-for-testing-changed-path@v0.0.4'],
-      flags,
-      'add-with-prefix-flag',
-      async config => {
-        expect(await fs.exists(dummyPath)).toEqual(true);
-        const targetAfter = await fs.readlink(dummyPath);
-
-        expect(targetAfter).not.toEqual(targetBefore);
-      },
+  await runGlobal(['add', 'dummy-for-testing-changed-path@v0.0.3'], flags, 'add-with-prefix-flag', async config => {
+    const targetPath = path.join(tmpGlobalFolder, 'node_modules', 'dummy-for-testing-changed-path');
+    expect(await fs.exists(targetPath)).toEqual(true);
+    expect(await linkAt(config, 'node_modules', '.bin', 'dummy-for-testing-changed-path')).toEqual(
+      '../dummy-for-testing-changed-path/index.js',
     );
   });
+
+  return runGlobal(['upgrade', 'dummy-for-testing-changed-path@v0.0.4'], flags, 'add-with-prefix-flag', async config =>
+    expect(await linkAt(config, 'node_modules', '.bin', 'dummy-for-testing-changed-path')).toEqual(
+      '../dummy-for-testing-changed-path/src/app.js',
+    ),
+  );
 });

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -3,12 +3,11 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
-import * as promise from '../../util/promise.js';
 import * as fs from '../../util/fs.js';
 import {getBinFolder as getGlobalBinFolder} from './global';
 
 const invariant = require('invariant');
-const cmdShim = promise.promisify(require('@zkochan/cmd-shim'));
+const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 
 export async function getRegistryFolder(config: Config, name: string): Promise<string> {

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -17,7 +17,7 @@ import {satisfiesWithPrereleases} from './util/semver.js';
 import WorkspaceLayout from './workspace-layout.js';
 
 const invariant = require('invariant');
-const cmdShim = promise.promisify(require('@zkochan/cmd-shim'));
+const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 // Concurrency for creating bin links disabled because of the issue #1961
 const linkBinConcurrency = 1;


### PR DESCRIPTION
* fix(install): Fix bin-links and related hung installs on Windows

**Summary**

This is a fix for #5927 which broke all installs with bin links on
Windows. Fixes #5927, fixes #5971. Also #5968 was probably about this.

**Test plan**

AppVeyor tests should start passing (instead of timing out).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
