### PR TITLE
Expose font fallback

### DIFF
--- a/resources/win-chocolatey/tools/chocolateyinstall.ps1.in
+++ b/resources/win-chocolatey/tools/chocolateyinstall.ps1.in
@@ -1,10 +1,12 @@
-﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+$ErrorActionPreference = 'Stop'; # stop on all errors
+
 $packageName = 'yarn'
+
 $packageArgs = @{
   packageName = $packageName
   softwareName = 'Yarn*'
   fileType = 'msi'
-  silentArgs = "/qn /norestart /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`""
+  silentArgs = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
   checksumType = 'sha256'
 
@@ -20,9 +22,17 @@ if (Test-Path "${env:ProgramFiles(x86)}\Yarn\package.json") {
 } else {
   $path = "$env:ProgramFiles\Yarn\package.json"
 }
+
 $script = @"
   (Get-Content -Path '$path') ``
     -replace 'installationMethod":.+', 'installationMethod": "choco",' ``
     | Set-Content '$path'
 "@
+
 Start-ChocolateyProcessAsAdmin -Statements $script
+
+if (-Not (Get-Command "node" -errorAction SilentlyContinue)) {
+  Write-Host "Yarn requires NodeJS to be installed. To install, use either of the commands below:"
+  Write-Host "choco install nodejs"
+  Write-Host "choco install nodejs-lts"
+}

--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -23,8 +23,11 @@ control over whether lifecycle scripts are executed for packages and package
 hashes are stored in the lockfile to ensure you get the same package each time.
 
 **Performance:** We're always performing operations such as package resolving and
-fetching in parallel. This ensures little idle time and maximum resource
-utilization.
+fetching in parallel. This ensures little idle time and maximum resource utilization.
+			
+**Notes:** This package requires NodeJS. You can install via either the 
+[nodejs](https://chocolatey.org/packages/nodejs) or [nodejs-lts](https://chocolatey.org/packages/nodejs-lts) 
+package if you do not have it installed already.
 		</description>
 		<projectUrl>https://yarnpkg.com/</projectUrl>
 		<packageSourceUrl>https://github.com/yarnpkg/yarn/tree/master/resources/win-chocolatey</packageSourceUrl>
@@ -35,9 +38,6 @@ utilization.
 		<docsUrl>https://yarnpkg.com/en/docs/</docsUrl>
 		<bugTrackerUrl>https://github.com/yarnpkg/yarn/issues</bugTrackerUrl>
 		<releaseNotes>https://github.com/yarnpkg/yarn/releases/tag/v$version$</releaseNotes>
-		<dependencies>
-			<dependency id="nodejs-lts" version="6.0" />
-		</dependencies>
 	</metadata>
 
 	<files>


### PR DESCRIPTION
**Summary**

Fixes #6439 

The chocolately install has always been full of log spam due to an incorrectly written `/l*v` flag, but those logs are also unneeded since the output has no useful info so I just removed them (this can be reversed to just fix the flag if y'all really want it back).

This also removes the bad `nodejs-lts` nuget dependency added in #5925. It now has no dependency, and instead logs out to inform the user to install node if it's missing.

**Test plan**

* `choco uninstall yarn`
* Replace the `{VERSION}` and `{CHECKSUM}` placeholders manually or do a full build (I manually replaced)
* `.\chocolateyinstall.ps1`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
